### PR TITLE
ci: Only run test pipeline on specific triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Run tests
 
 on:
   pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
   push:
     branches:
     - main


### PR DESCRIPTION
Recommended for use with Graphite. See
https://graphite.dev/docs/github-configuration-guidelines#github-actions
for more info.