### PR TITLE
ci: Auto-approve on PR review

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -3,14 +3,23 @@ name: Auto-Approve
 on:
   issue_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
     if: |
-        github.event.issue.pull_request != ''
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request != ''
         && github.event.comment.user.login == 'Mr-Pepe'
         && contains(github.event.comment.body, 'LGTM')
+      ) || (
+        github.event_name == 'pull_request_review'
+        && github.event.review.user.login == 'Mr-Pepe'
+        && github.event.review.body == 'LGTM'
+      )
     permissions:
       pull-requests: write
     steps:
@@ -18,7 +27,7 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          await github.pulls.createReview({
+          await github.rest.pulls.createReview({
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: context.issue.number,


### PR DESCRIPTION
Fixes a bug introduced during the upgrade to node.js 20 and now also
approves PRs that have been reviewed with an `LGTM` comment.