### PR TITLE
ci: Prevent duplicate concurrent CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: "0 0 * * 0" # Run on Sundays
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || ''}}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
https://graphite.dev/docs/troubleshooting#why-are-my-actions-running-twice