### PR TITLE
chore: Update example/.gitignore

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -31,7 +31,6 @@
 /build/
 
 # Web related
-lib/generated_plugin_registrant.dart
 
 # Symbolication related
 app.*.symbols


### PR DESCRIPTION
Flutter automatically removes one line from the `.gitignore` when
running `flutter build web`.