### PR TITLE
build: Move `fluttertoast` dependency to example

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,7 +81,7 @@ packages:
     source: sdk
     version: "0.0.0"
   fluttertoast:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: fluttertoast
       sha256: "7eae679e596a44fdf761853a706f74979f8dd3cd92cf4e23cae161fda091b847"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -30,6 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  fluttertoast: ^8.2.6
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -203,19 +203,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_plugins:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
-  fluttertoast:
-    dependency: "direct main"
-    description:
-      name: fluttertoast
-      sha256: "7eae679e596a44fdf761853a706f74979f8dd3cd92cf4e23cae161fda091b847"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.2.6"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  fluttertoast: ^8.0.8
   http: ^1.1.2
   provider: ^6.0.5
   svg_path_parser: ^1.0.0


### PR DESCRIPTION
Fluttertoast is only used in the example, but not in the library itself.