### PR TITLE
fix: Improve animations when background is enabled

### DIFF
--- a/lib/src/brush.dart
+++ b/lib/src/brush.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// A custom painter for drawing brush strokes.
+class Brush extends CustomPainter {
+  Brush(
+    this.points, {
+    required this.brushColor,
+    required this.brushWidth,
+  });
+  final List<Offset> points;
+  final Color brushColor;
+  final double brushWidth;
+
+  @override
+  bool shouldRepaint(Brush oldDelegate) {
+    return oldDelegate.points != points;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()
+      ..color = brushColor
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = brushWidth;
+
+    for (int i = 0; i < points.length - 1; i++) {
+      canvas.drawLine(points[i], points[i + 1], paint);
+    }
+  }
+}

--- a/lib/src/character_painter.dart
+++ b/lib/src/character_painter.dart
@@ -1,0 +1,324 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:stroke_order_animator/src/distance_2_d.dart';
+import 'package:stroke_order_animator/src/stroke_order.dart';
+import 'package:stroke_order_animator/src/stroke_order_animation_controller.dart';
+
+final _contourCache = <StrokeOrder, List<(PathMetric, PathMetric)?>>{};
+
+/// A custom painter for displaying a stroke order diagram.
+///
+/// The painter draws the stroke order diagram based on the provided
+/// [StrokeOrderAnimationController].
+class CharacterPainter extends CustomPainter {
+  CharacterPainter(this.controller)
+      : animationController = _getAnimationController(controller),
+        shouldPaintStroke = _getWhichStrokesToPaint(controller),
+        outlinePaint = Paint()
+          ..color = controller.outlineColor
+          ..strokeWidth = controller.outlineWidth
+          ..style = PaintingStyle.stroke,
+        backgroundPaint = Paint()
+          ..color = controller.backgroundColor
+          ..style = PaintingStyle.fill,
+        medianPaint = Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = controller.medianWidth
+          ..color = controller.medianColor,
+        strokePaints = _getStrokePaints(controller),
+        contourPaths = _getContourPaths(controller.strokeOrder),
+        super(repaint: _getAnimationController(controller));
+
+  final StrokeOrderAnimationController controller;
+
+  final Animation<double>? animationController;
+
+  final List<bool> shouldPaintStroke;
+
+  final Paint outlinePaint;
+  final Paint backgroundPaint;
+  final List<Paint> strokePaints;
+  final Paint medianPaint;
+
+  final List<(PathMetric, PathMetric)?> contourPaths;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    _paintBackground(canvas, size);
+
+    for (var i = 0; i < controller.strokeOrder.strokeOutlines.length; i++) {
+      if (i == controller.currentStroke &&
+          animationController != null &&
+          contourPaths[i] != null) {
+        _paintAnimatedStroke(canvas, size, i);
+      } else if (shouldPaintStroke[i]) {
+        _paintStroke(canvas, size, i);
+      }
+
+      if (controller.showMedian) {
+        _paintMedian(canvas, size, i);
+      }
+    }
+  }
+
+  void _paintBackground(Canvas canvas, Size size) {
+    final outlines = controller.strokeOrder.strokeOutlines;
+    for (var i = 0; i < outlines.length; i++) {
+      // Paint the background only for those strokes that are not getting
+      // painted with the actual stroke color later
+      if (controller.showBackground && !shouldPaintStroke[i]) {
+        canvas.drawPath(
+          _scalePath(outlines[i], size),
+          backgroundPaint,
+        );
+
+        if (controller.showOutline) {
+          canvas.drawPath(
+            _scalePath(outlines[i], size),
+            outlinePaint,
+          );
+        }
+      }
+    }
+  }
+
+  void _paintStroke(Canvas canvas, Size size, int i) {
+    canvas.drawPath(
+      _scalePath(controller.strokeOrder.strokeOutlines[i], size),
+      strokePaints[i],
+    );
+    if (controller.showOutline) {
+      canvas.drawPath(
+        _scalePath(controller.strokeOrder.strokeOutlines[i], size),
+        outlinePaint,
+      );
+    }
+  }
+
+  void _paintAnimatedStroke(Canvas canvas, Size size, int i) {
+    final firstPath = contourPaths[i]!.$1;
+    final secondPath = contourPaths[i]!.$2;
+
+    final animationProgress = animationController?.value ?? 1;
+
+    Path getFirstPathFragment() {
+      return firstPath.extractPath(0, animationProgress * firstPath.length);
+    }
+
+    final secondPathFragment = secondPath.extractPath(
+      secondPath.length - animationProgress * secondPath.length,
+      secondPath.length,
+    );
+
+    canvas.drawPath(
+      _scalePath(
+        getFirstPathFragment()..extendWithPath(secondPathFragment, Offset.zero),
+        size,
+      ),
+      strokePaints[i],
+    );
+
+    if (controller.showOutline) {
+      canvas.drawPath(
+        _scalePath(getFirstPathFragment(), size),
+        outlinePaint,
+      );
+      canvas.drawPath(
+        _scalePath(secondPathFragment, size),
+        outlinePaint,
+      );
+    }
+  }
+
+  void _paintMedian(Canvas canvas, Size size, int i) {
+    final medianPath = Path();
+    medianPath.moveTo(
+      controller.strokeOrder.medians[i][0].dx,
+      controller.strokeOrder.medians[i][0].dy,
+    );
+    for (final point in controller.strokeOrder.medians[i]) {
+      medianPath.lineTo(point.dx, point.dy);
+    }
+    canvas.drawPath(
+      _scalePath(medianPath, size),
+      medianPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(CharacterPainter oldDelegate) => true;
+}
+
+AnimationController? _getAnimationController(
+  StrokeOrderAnimationController controller,
+) {
+  if (controller.isQuizzing) {
+    return controller.hintAnimationController;
+  }
+
+  if (controller.isAnimating) {
+    return controller.strokeAnimationController;
+  }
+
+  return null;
+}
+
+/// Determine whether to use standard stroke color, radical color, or hint color.
+List<Paint> _getStrokePaints(StrokeOrderAnimationController controller) {
+  return List.generate(controller.strokeOrder.nStrokes, (index) {
+    if (controller.highlightRadical &&
+        controller.strokeOrder.radicalStrokeIndices.contains(index)) {
+      return Paint()..color = controller.radicalColor;
+    }
+
+    if (controller.isQuizzing && index == controller.currentStroke) {
+      return Paint()..color = controller.hintColor;
+    }
+
+    return Paint()..color = controller.strokeColor;
+  });
+}
+
+List<bool> _getWhichStrokesToPaint(StrokeOrderAnimationController controller) {
+  return List.generate(
+    controller.strokeOrder.nStrokes,
+    (index) => controller.showStroke && index < controller.currentStroke,
+  );
+}
+
+List<(PathMetric, PathMetric)?> _getContourPaths(
+  StrokeOrder strokeOrder,
+) {
+  if (_contourCache.containsKey(strokeOrder)) {
+    return _contourCache[strokeOrder]!;
+  }
+
+  final contourPaths = List.generate(strokeOrder.nStrokes, (i) {
+    if (strokeOrder.medians[i].isEmpty) {
+      return null;
+    }
+
+    final start = _getClosestPointOnPathAsDistanceOnPath(
+      strokeOrder.strokeOutlines[i],
+      strokeOrder.medians[i].first,
+    );
+
+    final end = _getClosestPointOnPathAsDistanceOnPath(
+      strokeOrder.strokeOutlines[i],
+      strokeOrder.medians[i].last,
+    );
+
+    if (start < 0 || end < 0) {
+      return null;
+    }
+
+    final List<Path> contourPaths = _extractContourPaths(
+      strokeOrder.strokeOutlines[i],
+      start,
+      end,
+    );
+
+    return (
+      contourPaths.first.computeMetrics().first,
+      contourPaths.last.computeMetrics().first
+    );
+  });
+
+  _contourCache[strokeOrder] = contourPaths;
+
+  return contourPaths;
+}
+
+/// Split the original path into two paths that follow the outline
+/// of the stroke from strokeStart to strokeEnd clockwise and counter-clockwise
+List<Path> _extractContourPaths(
+  Path strokeOutlinePath,
+  double strokeStartLength,
+  double strokeEndLength,
+) {
+  Path path1 = Path();
+  Path path2 = Path();
+
+  final metrics = strokeOutlinePath.computeMetrics().toList()[0];
+
+  if (strokeEndLength > strokeStartLength) {
+    path1 = metrics.extractPath(strokeStartLength, strokeEndLength);
+    path2 = metrics.extractPath(strokeEndLength, metrics.length);
+    path2.extendWithPath(
+      metrics.extractPath(0, strokeStartLength),
+      Offset.zero,
+    );
+  } else {
+    path1 = metrics.extractPath(strokeStartLength, metrics.length);
+    path1.extendWithPath(
+      metrics.extractPath(0, strokeEndLength),
+      Offset.zero,
+    );
+    path2 = metrics.extractPath(strokeEndLength, strokeStartLength);
+  }
+
+  // path1 leads from start to end, path2 continues from end to start
+  return [path1, path2];
+}
+
+double _getClosestPointOnPathAsDistanceOnPath(Path path, Offset queryPoint) {
+  final PathMetric metrics = path.computeMetrics().toList()[0];
+
+  const int nSteps = 100;
+  final double pathLength = metrics.length;
+  final double stepSize = pathLength / nSteps;
+
+  final List<Offset> pointsOnPath = [];
+
+  double minDistance = double.infinity;
+
+  // x, y, and length on the path where that point lies
+  double closestPoint = -1;
+
+  // Sample nSteps points on the path
+  for (var step = 0.0; step < pathLength; step += stepSize) {
+    final tangent = metrics.getTangentForOffset(step)!;
+    pointsOnPath.add(tangent.position);
+  }
+
+  // Find the point on the path closest to the query
+  for (var iPoint = 0; iPoint < pointsOnPath.length; iPoint++) {
+    final point = pointsOnPath[iPoint];
+    final distance = distance2D(point, queryPoint);
+    if (distance < minDistance) {
+      minDistance = distance;
+      closestPoint = iPoint * stepSize;
+    }
+  }
+
+  return closestPoint;
+}
+
+// Scale a path from the 1024x1024 coordinate system to the given size.
+Path _scalePath(Path path, Size size) {
+  if (size == const Size(1024, 1024)) {
+    return path;
+  }
+
+  return path.transform(
+    Matrix4(
+      size.width / 1024,
+      0,
+      0,
+      0,
+      0,
+      size.height / 1024,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      0,
+      1,
+    ).storage,
+  );
+}

--- a/lib/src/stroke_order.dart
+++ b/lib/src/stroke_order.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:stroke_order_animator/stroke_order_animator.dart';
 import 'package:svg_path_parser/svg_path_parser.dart';
@@ -9,7 +10,7 @@ import 'package:svg_path_parser/svg_path_parser.dart';
 /// A JSON string retrieved via [downloadStrokeOrder] can be passed directly to
 /// the constructor.
 class StrokeOrder {
-  StrokeOrder(String strokeOrderJson) {
+  StrokeOrder(String strokeOrderJson) : _rawJson = strokeOrderJson {
     final parsedJson = _parseJson(strokeOrderJson);
 
     strokeOutlines = _parseStrokeOutlines(parsedJson);
@@ -23,6 +24,8 @@ class StrokeOrder {
       );
     }
   }
+
+  final String _rawJson;
 
   /// Path information describing the outline of each strokes.
   late final List<Path> strokeOutlines;
@@ -101,5 +104,13 @@ class StrokeOrder {
         'Invalid radical stroke indices in stroke order JSON',
       );
     }
+  }
+
+  @override
+  int get hashCode => _rawJson.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other is StrokeOrder && other._rawJson == _rawJson;
   }
 }

--- a/lib/src/stroke_order_animation_controller.dart
+++ b/lib/src/stroke_order_animation_controller.dart
@@ -428,8 +428,7 @@ class StrokeOrderAnimationController extends ChangeNotifier {
     _onCorrectStrokeCallbacks.add(callback);
   }
 
-  void checkStroke(List<Offset?> rawStroke) {
-    final List<Offset> stroke = getNonNullPointsFrom(rawStroke);
+  void checkStroke(List<Offset> stroke) {
     final strokeLength = getLength(stroke);
 
     if (isQuizzing &&
@@ -437,7 +436,7 @@ class StrokeOrderAnimationController extends ChangeNotifier {
         strokeLength > 0) {
       if (strokeIsCorrect(strokeLength, stroke)) {
         notifyCorrectStrokeCallbacks();
-        _summary.correctStrokePaths[currentStroke] = stroke;
+        _summary.correctStrokePaths[currentStroke] = List.from(stroke);
         _setCurrentStroke(currentStroke + 1);
 
         if (currentStroke == strokeOrder.nStrokes) {
@@ -588,18 +587,6 @@ class StrokeOrderAnimationController extends ChangeNotifier {
     }
 
     return path;
-  }
-
-  List<Offset> getNonNullPointsFrom(List<Offset?> rawPoints) {
-    final List<Offset> points = [];
-
-    for (final point in rawPoints) {
-      if (point != null) {
-        points.add(point);
-      }
-    }
-
-    return points;
   }
 
   void _setCurrentStroke(int value) {

--- a/lib/src/stroke_order_animator.dart
+++ b/lib/src/stroke_order_animator.dart
@@ -1,8 +1,7 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
-import 'package:stroke_order_animator/src/distance_2_d.dart';
-import 'package:stroke_order_animator/stroke_order_animator.dart';
+import 'package:stroke_order_animator/src/brush.dart';
+import 'package:stroke_order_animator/src/character_painter.dart';
+import 'package:stroke_order_animator/src/stroke_order_animation_controller.dart';
 
 /// A widget for displaying a stroke order diagram.
 ///
@@ -25,7 +24,8 @@ class StrokeOrderAnimator extends StatefulWidget {
 }
 
 class StrokeOrderAnimatorState extends State<StrokeOrderAnimator> {
-  final List<Offset?> _points = <Offset>[];
+  final List<Offset> _currentUserStroke = <Offset>[];
+  bool _userStrokeLeftCanvas = false;
 
   @override
   void initState() {
@@ -34,380 +34,101 @@ class StrokeOrderAnimatorState extends State<StrokeOrderAnimator> {
 
   @override
   Widget build(BuildContext context) {
+    final controller = widget._controller;
+
     return GestureDetector(
       onPanUpdate: (DragUpdateDetails details) {
-        setState(() {
-          final RenderBox box = context.findRenderObject()! as RenderBox;
-          final Offset point = box.globalToLocal(details.globalPosition);
+        // User continues stroke
+        if (_userStrokeLeftCanvas) {
+          return;
+        }
 
-          if (point.dx >= 0 &&
-              point.dx <= box.size.width &&
-              point.dy >= 0 &&
-              point.dy <= box.size.height) {
-            _points.add(point);
+        final RenderBox box = context.findRenderObject()! as RenderBox;
+        final Offset point = box.globalToLocal(details.globalPosition);
+
+        setState(() {
+          if (_pointIsOnCanvas(point, box)) {
+            _currentUserStroke.add(
+              // Normalize point to 1024x1024 coordinate system
+              Offset(point.dx / box.size.width, point.dy / box.size.height) *
+                  1024,
+            );
           } else {
-            if (_points.last != null) {
-              _points.add(null);
-            }
+            _userStrokeLeftCanvas = true;
           }
         });
       },
       onPanEnd: (DragEndDetails details) {
-        widget._controller.checkStroke(
-          _points
-              .map(
-                (point) => point != null
-                    ? Offset(
-                        point.dx * 1024 / widget.size.width,
-                        point.dy * 1024 / widget.size.height,
-                      )
-                    : null,
-              )
-              .toList(),
-        );
+        // User finished stroke
+        controller.checkStroke(_currentUserStroke);
         setState(() {
-          _points.clear();
+          _currentUserStroke.clear();
+          _userStrokeLeftCanvas = false;
         });
       },
-      child: Stack(
-        children: <Widget>[
-          ...List.generate(widget._controller.strokeOrder.nStrokes, (index) {
-            // Determine whether to use standard stroke color, radical color or hint color
-            Color strokeColor = widget._controller.strokeColor;
-
-            if (widget._controller.highlightRadical &&
-                widget._controller.strokeOrder.radicalStrokeIndices
-                    .contains(index)) {
-              strokeColor = widget._controller.radicalColor;
-            }
-
-            if (widget._controller.isQuizzing &&
-                index == widget._controller.currentStroke) {
-              strokeColor = widget._controller.hintColor;
-            }
-
-            final animate = index == widget._controller.currentStroke &&
-                (widget._controller.isAnimating ||
-                    widget._controller.isQuizzing);
-            final animationController = widget._controller.isQuizzing
-                ? widget._controller.hintAnimationController
-                : widget._controller.strokeAnimationController;
-
-            return SizedBox(
-              width: widget.size.width,
-              height: widget.size.height,
-              child: CustomPaint(
-                painter: StrokePainter(
-                  widget._controller.strokeOrder.strokeOutlines[index],
-                  showStroke: widget._controller.showStroke &&
-                      index < widget._controller.currentStroke,
-                  strokeColor: strokeColor,
-                  showOutline: widget._controller.showOutline,
-                  outlineColor: widget._controller.outlineColor,
-                  outlineWidth: widget._controller.outlineWidth,
-                  showBackground: widget._controller.showBackground,
-                  backgroundColor: widget._controller.backgroundColor,
-                  showMedian: widget._controller.showMedian,
-                  medianColor: widget._controller.medianColor,
-                  medianWidth: widget._controller.medianWidth,
-                  animate: animate,
-                  animation: animationController,
-                  median: widget._controller.strokeOrder.medians[index],
-                ),
+      child: SizedBox(
+        width: widget.size.width,
+        height: widget.size.height,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            CustomPaint(painter: CharacterPainter(controller)),
+            if (controller.showUserStroke)
+              ..._paintCorrectUserStrokes(controller, widget.size),
+            if (controller.isQuizzing && _currentUserStroke.isNotEmpty)
+              _paintCurrentUserStroke(
+                _currentUserStroke,
+                controller,
+                widget.size,
               ),
-            );
-          }),
-          if (widget._controller.showUserStroke)
-            ...paintCorrectStrokes(
-              widget._controller.summary.correctStrokePaths,
-              brushColor: widget._controller.brushColor,
-              brushWidth: widget._controller.brushWidth,
-            ),
-          if (widget._controller.isQuizzing)
-            CustomPaint(
-              painter: Brush(
-                _points,
-                brushColor: widget._controller.brushColor,
-                brushWidth: widget._controller.brushWidth,
-              ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }
-
-  List<CustomPaint> paintCorrectStrokes(
-    List<List<Offset>> correctStrokePaths, {
-    Color brushColor = Colors.black,
-    double brushWidth = 8,
-  }) {
-    final List<CustomPaint> brushStrokes = [];
-
-    for (final strokePath in correctStrokePaths) {
-      if (strokePath.isNotEmpty) {
-        brushStrokes.add(
-          CustomPaint(
-            painter: Brush(
-              strokePath,
-              brushColor: brushColor,
-              brushWidth: brushWidth,
-            ),
-          ),
-        );
-      }
-    }
-
-    return brushStrokes;
-  }
 }
 
-class StrokePainter extends CustomPainter {
-  StrokePainter(
-    this.strokeOutlinePath, {
-    required this.showStroke,
-    required this.strokeColor,
-    required this.showBackground,
-    required this.backgroundColor,
-    required this.showOutline,
-    required this.outlineColor,
-    required this.outlineWidth,
-    required this.showMedian,
-    required this.medianColor,
-    required this.medianWidth,
-    required this.animate,
-    required this.animation,
-    required this.median,
-  }) : super(repaint: animation);
-  // If the stroke should be animated, an animation and the median have to be provided
-  final bool animate;
-  final Animation<double>? animation;
-  final Path strokeOutlinePath;
-  final Color strokeColor;
-  final Color outlineColor;
-  final double outlineWidth;
-  final bool showBackground;
-  final Color backgroundColor;
-  final Color medianColor;
-  final double medianWidth;
-  final bool showOutline;
-  final bool showStroke;
-  final bool showMedian;
-  final List<Offset> median;
-
-  double strokeStart = -1;
-  double strokeEnd = -1;
-
-  Path visibleStroke = Path();
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    if (showBackground) {
-      final backgroundPaint = Paint()
-        ..color = backgroundColor
-        ..style = PaintingStyle.fill;
-
-      canvas.drawPath(
-        _scalePath(strokeOutlinePath, size),
-        backgroundPaint,
-      );
-    }
-
-    if (strokeStart < 0) {
-      // Calculate the points on strokeOutlinePath that are closest to the start and end points of the median
-      strokeStart = getClosestPointOnPathAsDistanceOnPath(
-        strokeOutlinePath,
-        median.first,
-      );
-      strokeEnd =
-          getClosestPointOnPathAsDistanceOnPath(strokeOutlinePath, median.last);
-    }
-
-    final strokePaint = Paint()
-      ..color = strokeColor
-      ..style = PaintingStyle.fill;
-
-    if (animate == true && median.isNotEmpty) {
-      if (strokeStart >= 0 && strokeEnd >= 0) {
-        // Split the original path into two paths that follow the outline
-        // of the stroke from strokeStart to strokeEnd clockwise and counter-clockwise
-        final List<Path> contourPaths =
-            extractContourPaths(strokeOutlinePath, strokeStart, strokeEnd);
-
-        // Go on the first contourPath first, then jump over to the second path and go back to the start
-        final lenFirstPath = contourPaths.first.computeMetrics().first.length;
-        final lenSecondPath = contourPaths.last.computeMetrics().first.length;
-
-        final Path finalOutlinePath = contourPaths.first
-            .computeMetrics()
-            .first
-            .extractPath(0, (animation?.value ?? 1) * lenFirstPath);
-        finalOutlinePath.extendWithPath(
-          contourPaths.last.computeMetrics().first.extractPath(
-                lenSecondPath - (animation?.value ?? 1) * lenSecondPath,
-                lenSecondPath,
-              ),
-          Offset.zero,
-        );
-
-        canvas.drawPath(
-          _scalePath(finalOutlinePath, size),
-          strokePaint,
-        );
-      }
-    } else if (showStroke) {
-      canvas.drawPath(
-        _scalePath(strokeOutlinePath, size),
-        strokePaint,
-      );
-    }
-
-    if (showOutline) {
-      final borderPaint = Paint()
-        ..color = outlineColor
-        ..strokeWidth = outlineWidth
-        ..style = PaintingStyle.stroke;
-      canvas.drawPath(
-        _scalePath(strokeOutlinePath, size),
-        borderPaint,
-      );
-    }
-
-    if (showMedian) {
-      final medianPath = Path();
-      medianPath.moveTo(median[0].dx, median[0].dy);
-      for (final point in median) {
-        medianPath.lineTo(point.dx, point.dy);
-      }
-      canvas.drawPath(
-        _scalePath(medianPath, size),
-        Paint()
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = medianWidth
-          ..color = medianColor,
-      );
-    }
-  }
-
-  @override
-  bool shouldRepaint(CustomPainter oldDelegate) => true;
-
-  Path _scalePath(Path path, Size size) {
-    if (size == const Size(1024, 1024)) {
-      return path;
-    }
-
-    return path.transform(
-      Matrix4(
-        size.width / 1024,
-        0,
-        0,
-        0,
-        0,
-        size.height / 1024,
-        0,
-        0,
-        0,
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        1,
-      ).storage,
-    );
-  }
+bool _pointIsOnCanvas(Offset point, RenderBox box) {
+  return point.dx >= 0 &&
+      point.dx <= box.size.width &&
+      point.dy >= 0 &&
+      point.dy <= box.size.height;
 }
 
-List<Path> extractContourPaths(
-  Path strokeOutlinePath,
-  double strokeStartLength,
-  double strokeEndLength,
+List<CustomPaint> _paintCorrectUserStrokes(
+  StrokeOrderAnimationController controller,
+  Size size,
 ) {
-  Path path1 = Path();
-  Path path2 = Path();
-
-  final metrics = strokeOutlinePath.computeMetrics().toList()[0];
-
-  if (strokeEndLength > strokeStartLength) {
-    path1 = metrics.extractPath(strokeStartLength, strokeEndLength);
-    path2 = metrics.extractPath(strokeEndLength, metrics.length);
-    path2.extendWithPath(
-      metrics.extractPath(0, strokeStartLength),
-      Offset.zero,
-    );
-  } else {
-    path1 = metrics.extractPath(strokeStartLength, metrics.length);
-    path1.extendWithPath(
-      metrics.extractPath(0, strokeEndLength),
-      Offset.zero,
-    );
-    path2 = metrics.extractPath(strokeEndLength, strokeStartLength);
-  }
-
-  // path1 leads from start to end, path2 continues from end to start
-  return [path1, path2];
+  return controller.summary.correctStrokePaths
+      .where((stroke) => stroke.isNotEmpty)
+      .map(
+        (stroke) => CustomPaint(
+          painter: Brush(
+            _scaleUserStroke(stroke, size),
+            brushColor: controller.brushColor,
+            brushWidth: controller.brushWidth,
+          ),
+        ),
+      )
+      .toList();
 }
 
-double getClosestPointOnPathAsDistanceOnPath(Path path, Offset queryPoint) {
-  final PathMetric metrics = path.computeMetrics().toList()[0];
-
-  const int nSteps = 100;
-  final double pathLength = metrics.length;
-  final double stepSize = pathLength / nSteps;
-
-  final List<Offset> pointsOnPath = [];
-
-  double minDistance = double.infinity;
-
-  // x, y, and length on the path where that point lies
-  double closestPoint = -1;
-
-  // Sample nSteps points on the path
-  for (var step = 0.0; step < pathLength; step += stepSize) {
-    final tangent = metrics.getTangentForOffset(step)!;
-    pointsOnPath.add(tangent.position);
-  }
-
-  // Find the point on the path closest to the query
-  for (var iPoint = 0; iPoint < pointsOnPath.length; iPoint++) {
-    final point = pointsOnPath[iPoint];
-    final distance = distance2D(point, queryPoint);
-    if (distance < minDistance) {
-      minDistance = distance;
-      closestPoint = iPoint * stepSize;
-    }
-  }
-
-  return closestPoint;
+CustomPaint _paintCurrentUserStroke(
+  List<Offset> stroke,
+  StrokeOrderAnimationController controller,
+  Size size,
+) {
+  return CustomPaint(
+    painter: Brush(
+      _scaleUserStroke(stroke, size),
+      brushColor: controller.brushColor,
+      brushWidth: controller.brushWidth,
+    ),
+  );
 }
 
-class Brush extends CustomPainter {
-  Brush(
-    this.points, {
-    this.brushColor = Colors.black,
-    this.brushWidth = 8.0,
-  });
-  final List<Offset?> points;
-  final Color brushColor;
-  final double brushWidth;
-
-  @override
-  bool shouldRepaint(Brush oldDelegate) {
-    return oldDelegate.points != points;
-  }
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final Paint paint = Paint()
-      ..color = brushColor
-      ..strokeCap = StrokeCap.round
-      ..strokeWidth = brushWidth;
-
-    for (int i = 0; i < points.length - 1; i++) {
-      if (points[i] != null && points[i + 1] != null) {
-        canvas.drawLine(points[i]!, points[i + 1]!, paint);
-      }
-    }
-  }
+List<Offset> _scaleUserStroke(List<Offset> stroke, Size size) {
+  return stroke
+      .map((p) => Offset(p.dx * size.width, p.dy * size.height) / 1024)
+      .toList();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stroke_order_animator
-description: "Stroke order animations and quizzes for Chinese characters."
+description: "Stroke order animations and practice quizzes for Chinese characters."
 
 # Version gets set by cider during publishing
 version: 0.0.0

--- a/test/unit/stroke_order_animator_test.dart
+++ b/test/unit/stroke_order_animator_test.dart
@@ -62,37 +62,24 @@ void main() {
         ),
       );
 
-      // Initially empty
-      Finder brushFinder = find.byType(CustomPaint);
-      // There is one brush for every stroke and one more for the active stroke during drawing
-      expect(brushFinder, findsNWidgets(controller.strokeOrder.nStrokes + 1));
+      final customPaintFinder = find.byType(CustomPaint);
+      // Only the character itself is painted
+      expect(customPaintFinder, findsNWidgets(1));
 
       // One correct stroke
       controller.checkStroke(correctStroke00);
       await tester.pump();
-      brushFinder = find.byType(CustomPaint);
-      expect(
-        brushFinder,
-        findsNWidgets(controller.strokeOrder.nStrokes + 1 + 1),
-      );
+      expect(customPaintFinder, findsNWidgets(1 + 1));
 
       // One incorrect stroke
       controller.checkStroke(wrongStroke00);
       await tester.pump();
-      brushFinder = find.byType(CustomPaint);
-      expect(
-        brushFinder,
-        findsNWidgets(controller.strokeOrder.nStrokes + 1 + 1),
-      );
+      expect(customPaintFinder, findsNWidgets(1 + 1));
 
       // One more correct stroke
       controller.checkStroke(correctStroke01);
       await tester.pump();
-      brushFinder = find.byType(CustomPaint);
-      expect(
-        brushFinder,
-        findsNWidgets(controller.strokeOrder.nStrokes + 1 + 2),
-      );
+      expect(customPaintFinder, findsNWidgets(1 + 2));
     });
 
     testWidgets('Strokes stay on screen after quiz finished',
@@ -125,8 +112,8 @@ void main() {
       );
 
       await tester.pump();
-      final brushFinder = find.byType(CustomPaint);
-      expect(brushFinder, findsNWidgets(controller.strokeOrder.nStrokes + 3));
+      final customPaintFinder = find.byType(CustomPaint);
+      expect(customPaintFinder, findsNWidgets(1 + 3));
     });
 
     testWidgets('Strokes stay on screen only if enabled',
@@ -156,16 +143,13 @@ void main() {
       );
 
       await tester.pump();
-      Finder brushFinder = find.byType(CustomPaint);
-      expect(brushFinder, findsNWidgets(controller.strokeOrder.nStrokes + 1));
+      final Finder customPaintFinder = find.byType(CustomPaint);
+      // Only the character itself is painted
+      expect(customPaintFinder, findsNWidgets(1));
 
       controller.setShowUserStroke(true);
       await tester.pump();
-      brushFinder = find.byType(CustomPaint);
-      expect(
-        brushFinder,
-        findsNWidgets(controller.strokeOrder.nStrokes + 1 + 1),
-      );
+      expect(customPaintFinder, findsNWidgets(1 + 1));
     });
   });
 }

--- a/test/unit/stroke_order_test.dart
+++ b/test/unit/stroke_order_test.dart
@@ -65,4 +65,16 @@ void main() {
       });
     });
   });
+
+  test('Stroke order equality and hashing', () {
+    expect(
+      StrokeOrder(strokeOrderJsons['永']!).hashCode,
+      StrokeOrder(strokeOrderJsons['永']!).hashCode,
+    );
+
+    expect(
+      StrokeOrder(strokeOrderJsons['永']!),
+      StrokeOrder(strokeOrderJsons['永']!),
+    );
+  });
 }


### PR DESCRIPTION
There were some issues with how the strokes where overlapping each other
when the background was enabled. While I was at it, I refactored and
optimized the whole drawing part of the stroke order animations.