### PR TITLE
feat: Remove `provider` dependency

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:http/http.dart' as http;
-import 'package:provider/provider.dart';
 import 'package:stroke_order_animator/stroke_order_animator.dart';
 
 void main() {
@@ -29,6 +28,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
   final _httpClient = http.Client();
   final _textController = TextEditingController();
 
+  StrokeOrderAnimationController? _completedController;
   late Future<StrokeOrderAnimationController> _animationController;
 
   @override
@@ -36,11 +36,13 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     super.initState();
 
     _animationController = _loadStrokeOrder('永');
+    _animationController.then((a) => _completedController = a);
   }
 
   @override
   void dispose() {
     _httpClient.close();
+    _completedController?.dispose();
     super.dispose();
   }
 
@@ -129,6 +131,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
 
     setState(() {
       _animationController = _loadStrokeOrder(_textController.text);
+      _animationController.then((a) => _completedController = a);
     });
   }
 
@@ -160,111 +163,94 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
   }
 
   Widget _buildStrokeOrderAnimation(StrokeOrderAnimationController controller) {
-    return ChangeNotifierProvider<StrokeOrderAnimationController>.value(
-      value: controller,
-      child: Consumer<StrokeOrderAnimationController>(
-        builder: (context, controller, child) {
-          return StrokeOrderAnimator(
-            controller,
-            size: Size(300, 300),
-            key: UniqueKey(),
-          );
-        },
-      ),
+    return StrokeOrderAnimator(
+      controller,
+      size: Size(300, 300),
+      key: UniqueKey(),
     );
   }
 
   Widget _buildAnimationControls(StrokeOrderAnimationController controller) {
-    return ChangeNotifierProvider.value(
-      value: controller,
-      builder: (context, child) => Consumer<StrokeOrderAnimationController>(
-        builder: (context, controller, child) => Flexible(
-          child: GridView(
-            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-              childAspectRatio: 3,
-              crossAxisCount: 2,
-              mainAxisSpacing: 10,
-            ),
-            primary: false,
-            children: <Widget>[
-              MaterialButton(
-                onPressed: controller.isQuizzing
-                    ? null
-                    : (controller.isAnimating
-                        ? controller.stopAnimation
-                        : controller.startAnimation),
-                child: controller.isAnimating
-                    ? Text('Stop animation')
-                    : Text('Start animation'),
-              ),
-              MaterialButton(
-                onPressed: controller.isQuizzing
-                    ? controller.stopQuiz
-                    : controller.startQuiz,
-                child: controller.isQuizzing
-                    ? Text('Stop quiz')
-                    : Text('Start quiz'),
-              ),
-              MaterialButton(
-                onPressed: controller.isQuizzing ? null : controller.nextStroke,
-                child: Text('Next stroke'),
-              ),
-              MaterialButton(
-                onPressed:
-                    controller.isQuizzing ? null : controller.previousStroke,
-                child: Text('Previous stroke'),
-              ),
-              MaterialButton(
-                onPressed:
-                    controller.isQuizzing ? null : controller.showFullCharacter,
-                child: Text('Show full character'),
-              ),
-              MaterialButton(
-                onPressed: controller.reset,
-                child: Text('Reset'),
-              ),
-              MaterialButton(
-                onPressed: () {
-                  controller.setShowOutline(!controller.showOutline);
-                },
-                child: controller.showOutline
-                    ? Text('Hide outline')
-                    : Text('Show Outline'),
-              ),
-              MaterialButton(
-                onPressed: () {
-                  controller.setShowBackground(!controller.showBackground);
-                },
-                child: controller.showUserStroke
-                    ? Text('Hide background')
-                    : Text('Show background'),
-              ),
-              MaterialButton(
-                onPressed: () {
-                  controller.setShowMedian(!controller.showMedian);
-                },
-                child: controller.showMedian
-                    ? Text('Hide medians')
-                    : Text('Show medians'),
-              ),
-              MaterialButton(
-                onPressed: () {
-                  controller.setHighlightRadical(!controller.highlightRadical);
-                },
-                child: controller.highlightRadical
-                    ? Text('Unhighlight radical')
-                    : Text('Highlight radical'),
-              ),
-              MaterialButton(
-                onPressed: () {
-                  controller.setShowUserStroke(!controller.showUserStroke);
-                },
-                child: controller.showUserStroke
-                    ? Text('Hide user strokes')
-                    : Text('Show user strokes'),
-              ),
-            ],
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (context, child) => Flexible(
+        child: GridView(
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            childAspectRatio: 3,
+            crossAxisCount: 2,
+            mainAxisSpacing: 10,
           ),
+          primary: false,
+          children: <Widget>[
+            MaterialButton(
+              onPressed: controller.isQuizzing
+                  ? null
+                  : (controller.isAnimating
+                      ? controller.stopAnimation
+                      : controller.startAnimation),
+              child: controller.isAnimating
+                  ? Text('Stop animation')
+                  : Text('Start animation'),
+            ),
+            MaterialButton(
+              onPressed: controller.isQuizzing
+                  ? controller.stopQuiz
+                  : controller.startQuiz,
+              child: controller.isQuizzing
+                  ? Text('Stop quiz')
+                  : Text('Start quiz'),
+            ),
+            MaterialButton(
+              onPressed: controller.isQuizzing ? null : controller.nextStroke,
+              child: Text('Next stroke'),
+            ),
+            MaterialButton(
+              onPressed:
+                  controller.isQuizzing ? null : controller.previousStroke,
+              child: Text('Previous stroke'),
+            ),
+            MaterialButton(
+              onPressed:
+                  controller.isQuizzing ? null : controller.showFullCharacter,
+              child: Text('Show full character'),
+            ),
+            MaterialButton(
+              onPressed: controller.reset,
+              child: Text('Reset'),
+            ),
+            MaterialButton(
+              onPressed: () {
+                controller.setShowOutline(!controller.showOutline);
+              },
+              child: controller.showOutline
+                  ? Text('Hide outline')
+                  : Text('Show Outline'),
+            ),
+            MaterialButton(
+              onPressed: () {
+                controller.setShowMedian(!controller.showMedian);
+              },
+              child: controller.showMedian
+                  ? Text('Hide medians')
+                  : Text('Show medians'),
+            ),
+            MaterialButton(
+              onPressed: () {
+                controller.setHighlightRadical(!controller.highlightRadical);
+              },
+              child: controller.highlightRadical
+                  ? Text('Unhighlight radical')
+                  : Text('Highlight radical'),
+            ),
+            MaterialButton(
+              onPressed: () {
+                controller.setShowUserStroke(!controller.showUserStroke);
+              },
+              child: controller.showUserStroke
+                  ? Text('Hide user strokes')
+                  : Text('Show user strokes'),
+            ),
+          ],
         ),
       ),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -160,14 +160,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -176,14 +168,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
-  provider:
-    dependency: transitive
-    description:
-      name: provider
-      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/src/stroke_order_animation_controller.dart
+++ b/lib/src/stroke_order_animation_controller.dart
@@ -7,7 +7,7 @@ import 'package:stroke_order_animator/stroke_order_animator.dart';
 ///
 /// It must be passed as an argument to a [StrokeOrderAnimator] that handles
 /// the actual presentation of the diagram.
-/// It can additionally be consumed by an app to allow for
+/// It can additionally be consumed by a [ListenableBuilder] to allow for
 /// synchronization of control buttons with the animations.
 /// In order to control animations, a [TickerProvider] must be passed to the
 /// controller, for example using a [TickerProviderStateMixin].
@@ -34,6 +34,8 @@ import 'package:stroke_order_animator/stroke_order_animator.dart';
 /// * Show next/previous stroke
 /// * Show full character
 /// * Reset animation/quiz
+///
+/// Don't forget to call [dispose] when the controller is no longer needed.
 class StrokeOrderAnimationController extends ChangeNotifier {
   /// Creates a new [StrokeOrderAnimationController].
   ///
@@ -56,6 +58,8 @@ class StrokeOrderAnimationController extends ChangeNotifier {
   /// * Brush thickness in quiz mode
   /// * Number of wrong strokes before showing a hint in quiz mode
   /// * Hint color in quiz mode
+  ///
+  /// Don't forget to call [dispose] when the controller is no longer needed.
   StrokeOrderAnimationController(
     this._strokeOrder,
     TickerProvider tickerProvider, {

--- a/lib/src/stroke_order_animator.dart
+++ b/lib/src/stroke_order_animator.dart
@@ -17,8 +17,10 @@ class StrokeOrderAnimator extends StatefulWidget {
     this.size = const Size(1024, 1024),
     super.key,
   });
+
   final StrokeOrderAnimationController _controller;
   final Size size;
+
   @override
   StrokeOrderAnimatorState createState() => StrokeOrderAnimatorState();
 }
@@ -28,60 +30,58 @@ class StrokeOrderAnimatorState extends State<StrokeOrderAnimator> {
   bool _userStrokeLeftCanvas = false;
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final controller = widget._controller;
 
-    return GestureDetector(
-      onPanUpdate: (DragUpdateDetails details) {
-        // User continues stroke
-        if (_userStrokeLeftCanvas) {
-          return;
-        }
-
-        final RenderBox box = context.findRenderObject()! as RenderBox;
-        final Offset point = box.globalToLocal(details.globalPosition);
-
-        setState(() {
-          if (_pointIsOnCanvas(point, box)) {
-            _currentUserStroke.add(
-              // Normalize point to 1024x1024 coordinate system
-              Offset(point.dx / box.size.width, point.dy / box.size.height) *
-                  1024,
-            );
-          } else {
-            _userStrokeLeftCanvas = true;
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (context, child) => GestureDetector(
+        onPanUpdate: (DragUpdateDetails details) {
+          // User continues stroke
+          if (_userStrokeLeftCanvas) {
+            return;
           }
-        });
-      },
-      onPanEnd: (DragEndDetails details) {
-        // User finished stroke
-        controller.checkStroke(_currentUserStroke);
-        setState(() {
-          _currentUserStroke.clear();
-          _userStrokeLeftCanvas = false;
-        });
-      },
-      child: SizedBox(
-        width: widget.size.width,
-        height: widget.size.height,
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            CustomPaint(painter: CharacterPainter(controller)),
-            if (controller.showUserStroke)
-              ..._paintCorrectUserStrokes(controller, widget.size),
-            if (controller.isQuizzing && _currentUserStroke.isNotEmpty)
-              _paintCurrentUserStroke(
-                _currentUserStroke,
-                controller,
-                widget.size,
-              ),
-          ],
+
+          final RenderBox box = context.findRenderObject()! as RenderBox;
+          final Offset point = box.globalToLocal(details.globalPosition);
+
+          setState(() {
+            if (_pointIsOnCanvas(point, box)) {
+              _currentUserStroke.add(
+                // Normalize point to 1024x1024 coordinate system
+                Offset(point.dx / box.size.width, point.dy / box.size.height) *
+                    1024,
+              );
+            } else {
+              _userStrokeLeftCanvas = true;
+            }
+          });
+        },
+        onPanEnd: (DragEndDetails details) {
+          // User finished stroke
+          controller.checkStroke(_currentUserStroke);
+          setState(() {
+            _currentUserStroke.clear();
+            _userStrokeLeftCanvas = false;
+          });
+        },
+        child: SizedBox(
+          width: widget.size.width,
+          height: widget.size.height,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              CustomPaint(painter: CharacterPainter(controller)),
+              if (controller.showUserStroke)
+                ..._paintCorrectUserStrokes(controller, widget.size),
+              if (controller.isQuizzing && _currentUserStroke.isNotEmpty)
+                _paintCurrentUserStroke(
+                  _currentUserStroke,
+                  controller,
+                  widget.size,
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -355,14 +355,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.4"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -387,14 +379,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
-  provider:
-    dependency: "direct main"
-    description:
-      name: provider
-      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.2"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.1.2
-  provider: ^6.0.5
   svg_path_parser: ^1.0.0
 
 dev_dependencies:

--- a/test/unit/stroke_order_animator_test.dart
+++ b/test/unit/stroke_order_animator_test.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:provider/provider.dart';
 import 'package:stroke_order_animator/src/distance_2_d.dart';
 import 'package:stroke_order_animator/stroke_order_animator.dart';
 
@@ -49,16 +48,9 @@ void main() {
       controller.setShowUserStroke(true);
 
       await tester.pumpWidget(
-        ChangeNotifierProvider<StrokeOrderAnimationController>.value(
-          value: controller,
-          child: Consumer<StrokeOrderAnimationController>(
-            builder: (context, controller, child) {
-              return Directionality(
-                textDirection: TextDirection.ltr,
-                child: StrokeOrderAnimator(controller),
-              );
-            },
-          ),
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: StrokeOrderAnimator(controller),
         ),
       );
 
@@ -98,16 +90,9 @@ void main() {
       controller.checkStroke(correctStroke52);
 
       await tester.pumpWidget(
-        ChangeNotifierProvider<StrokeOrderAnimationController>.value(
-          value: controller,
-          child: Consumer<StrokeOrderAnimationController>(
-            builder: (context, controller, child) {
-              return Directionality(
-                textDirection: TextDirection.ltr,
-                child: StrokeOrderAnimator(controller),
-              );
-            },
-          ),
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: StrokeOrderAnimator(controller),
         ),
       );
 
@@ -129,16 +114,9 @@ void main() {
       controller.checkStroke(correctStroke50);
 
       await tester.pumpWidget(
-        ChangeNotifierProvider<StrokeOrderAnimationController>.value(
-          value: controller,
-          child: Consumer<StrokeOrderAnimationController>(
-            builder: (context, controller, child) {
-              return Directionality(
-                textDirection: TextDirection.ltr,
-                child: StrokeOrderAnimator(controller),
-              );
-            },
-          ),
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: StrokeOrderAnimator(controller),
         ),
       );
 


### PR DESCRIPTION
The `StrokeOrderAnimator` now uses a `ListenableBuilder` to directly
listen to the `StrokeOrderAnimationController`. This removes the need
for a `ChangeNotifierProvider` and `Consumer`.